### PR TITLE
Add button delete

### DIFF
--- a/src/app/core/services/candidate.service.ts
+++ b/src/app/core/services/candidate.service.ts
@@ -35,7 +35,7 @@ export class CandidateService {
   }
   
   deleteCandidate(id: string): Observable<string> {
-    return this.http.delete<string>(`${this.baseUrl}/${id}`);
+    return this.http.delete(`${this.baseUrl}/${id}`, { responseType: 'text' }) as Observable<string>;
   }
   
   


### PR DESCRIPTION
Added responseType: 'text' to handle text responses in getCandidateById, updateCandidate, and patchCandidate methods to avoid SyntaxError when backend returns plain text like "Candidate not found".