### PR TITLE
refactor: standardize interview and evaluation service endpoints unde…

### DIFF
--- a/src/app/core/services/interview-evaluation.service.ts
+++ b/src/app/core/services/interview-evaluation.service.ts
@@ -12,13 +12,13 @@ import { handleError } from '../constants/http-const';
 })
 export class InterviewEvaluationService {
 
-  private baseUrl = `${environment.apiUrl}/v1/interview`;
-  private apiUrl = `${environment.apiInterviews}/v1/interview`;
+  private baseUrl = `${environment.apiUrl}/v1/interviews`;
+  private apiUrl = `${environment.apiInterviews}/v1/interviews`;
 
   constructor(private http: HttpClient) { }
 
   getInterviewEvaluation = (interviewId: string): Observable<Evaluation> => {
-    return this.http.get<Evaluation>(`${this.apiUrl}/evaluation/${interviewId}`)
+    return this.http.get<Evaluation>(`${this.apiUrl}/${interviewId}/evaluation/`)
       .pipe(
         retry(2),
         catchError((error) => handleError("Fetching Interview Evaluation", error))

--- a/src/app/core/services/interview.service.ts
+++ b/src/app/core/services/interview.service.ts
@@ -9,7 +9,7 @@ import { ERROR_MESSAGES } from '../constants/error-messages.const';
 
 @Injectable({ providedIn: 'root' })
 export class InterviewService {
-    private readonly apiUrl = `${environment.apiInterviews}/interviews`;
+    private readonly apiUrl = `${environment.apiInterviews}/v1/interviews`;
     private loadingSubject = new BehaviorSubject<boolean>(false);
     public loading$ = this.loadingSubject.asObservable();
 
@@ -37,6 +37,8 @@ export class InterviewService {
             scheduledDate: interview.scheduledAt
         };
 
+        const interviewId = interview.id;
+
         if (!payload.candidateId || typeof payload.candidateId !== 'string') {
             return throwError(() => new Error(ERROR_MESSAGES.INTERVIEW.INVALID_CANDIDATE_ID));
         }
@@ -52,7 +54,7 @@ export class InterviewService {
 
         this.loadingSubject.next(true);
 
-        return this.http.post<string>(`${this.apiUrl}/generate-link`, payload).pipe(
+        return this.http.post<string>(`${this.apiUrl}/${interviewId}/generateLink`, payload).pipe(
             timeout(10000),
             retry(2),
             finalize(() => this.loadingSubject.next(false)),
@@ -77,7 +79,7 @@ export class InterviewService {
             return throwError(() => new Error(ERROR_MESSAGES.EMAIL.INVALID_SCHEDULED_DATE));
         }
 
-        return this.http.post<{ message: string }>(`${this.apiUrl}/send-email`, payload).pipe(
+        return this.http.post<{ message: string }>(`${this.apiUrl}/sendEmail`, payload).pipe(
             retry(2),
             catchError(this.handleError)
         );
@@ -91,7 +93,7 @@ export class InterviewService {
     };
 
     saveInterviewLink = (interviewId: string, link: string): Observable<any> => {
-        return this.http.put<any>(`${this.apiUrl}/${interviewId}/savelink`, { link }).pipe(
+        return this.http.put<any>(`${this.apiUrl}/${interviewId}/saveLink`, { link }).pipe(
             retry(2),
             catchError(this.handleError)
         );


### PR DESCRIPTION
**standardize Interview and Evaluation endpoints under /v1/interviews**

1. Interview Evaluation Service:

    - Changed root endpoint to /v1/interviews
 
    - Updated getInterviewEvaluation to use path /{interviewId}/evaluation

2.Interview Service:

   - Changed root endpoint to /v1/interviews (was /interviews)

   - Updated generateInterviewLink to /{interviewId}/generateLink

   - Renamed saveInterviewLink path from savelink to saveLink (camelCase)

   - Changed sendEmail endpoint to /sendEmail for consistency with camelCase naming