### PR TITLE
added destroy in services that subscribe to other observables, i also…

### DIFF
--- a/src/app/core/services/text-to-speech.service.ts
+++ b/src/app/core/services/text-to-speech.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Observable, throwError } from 'rxjs';
-import { catchError, finalize, retry, timeout } from 'rxjs/operators';
+import { BehaviorSubject, Observable, Subject, throwError } from 'rxjs';
+import { catchError, finalize, retry, takeUntil, timeout } from 'rxjs/operators';
 import { TTSProvider, TTSRequest, TTSConfig, TTSProviderType } from '../api/interfaces/tts.interface';
 import { TTSProviderFactory } from '../api/factories/tts-provider.factory';
 import { environment } from '../../../environments/environment';
@@ -18,6 +18,7 @@ export class TextToSpeechService implements OnDestroy {
   public loading$ = this.loadingSubject.asObservable();
   private errorSubject = new BehaviorSubject<string | null>(null);
   public error$ = this.errorSubject.asObservable();
+  private readonly destroy$ = new Subject<void>();
 
   constructor(private providerFactory: TTSProviderFactory) {
     this.config = environment.tts;
@@ -32,27 +33,49 @@ export class TextToSpeechService implements OnDestroy {
 
   speak = (text: string, voiceId?: string): void => {
     this.stop();
-    if (!text.trim()) {
-      this.errorSubject.next('Empty text provided');
+
+    if (!this.validateInput(text)) {
       return;
     }
 
+    this.prepareForSpeech();
+
+    const request = this.createSpeechRequest(text, voiceId);
+
+    this.generateSpeech(request);
+  }
+
+  private validateInput = (text: string): Boolean => {
+    if (!text.trim()) {
+      this.errorSubject.next('Empty text provided');
+      return false;
+    }
+    return true
+  }
+
+  private prepareForSpeech = (): void => {
     this.clearError();
     this.loadingSubject.next(true);
     this.abortController = new AbortController();
+  }
 
+  private createSpeechRequest = (text: string, voiceId?: string): TTSRequest => {
     const request: TTSRequest = {
       text: text.trim(),
       voiceId: voiceId || this.config.defaultVoiceId,
       settings: this.config.defaultSettings
     };
+    return request;
+  }
 
+  private generateSpeech = (request: TTSRequest):void => {
     this.provider.generateSpeech(request)
       .pipe(
         timeout(this.config.timeout),
         retry(this.config.retryAttempts),
         catchError(this.handleError),
-        finalize(() => this.loadingSubject.next(false))
+        finalize(() => this.loadingSubject.next(false)),
+        takeUntil(this.destroy$)
       )
       .subscribe({
         next: (response) => {
@@ -115,6 +138,8 @@ export class TextToSpeechService implements OnDestroy {
   }
 
   ngOnDestroy = (): void => {
+    this.destroy$.next();
+    this.destroy$.complete();
     this.stop();
   }
 }

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -29,7 +29,7 @@ import { ScrollPanelModule } from 'primeng/scrollpanel';
 @Component({
     selector: 'app-interview-meeting',
     standalone: true,
-    imports: [CommonModule, FormsModule, ButtonModule, CardModule, MessageModule, MessagesModule, InputTextModule, PanelModule, ProgressSpinnerModule, ToastModule, DividerModule, TagModule, SkeletonModule, AvatarModule,ScrollPanelModule],
+    imports: [CommonModule, FormsModule, ButtonModule, CardModule, MessageModule, MessagesModule, InputTextModule, PanelModule, ProgressSpinnerModule, ToastModule, DividerModule, TagModule, SkeletonModule, AvatarModule, ScrollPanelModule],
     templateUrl: './interview-meeting.component.html',
     providers: [MessageService, NotificationService],
     animations: [
@@ -123,7 +123,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
 
     @ViewChild('previewVideo') previewVideo!: ElementRef<HTMLVideoElement>;
     @ViewChild('interviewVideo') interviewVideo!: ElementRef<HTMLVideoElement>;
-@ViewChild('transcriptScroll') scrollPanel!: any;
+    @ViewChild('transcriptScroll') scrollPanel!: any;
     mediaRecorder!: MediaRecorder;
     recordedChunks: Blob[] = [];
     recordedBlobUrl: string | null = null;
@@ -540,17 +540,17 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
     }
 
     private scrollTranscriptToBottom(): void {
-    setTimeout(() => {
-        if (this.scrollPanel && this.scrollPanel.contentViewChild?.nativeElement) {
-            const el = this.scrollPanel.contentViewChild.nativeElement;
-            el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-            this.scrollPanel.moveBar(); 
-        }
-    }, 100);
-}
+        setTimeout(() => {
+            if (this.scrollPanel && this.scrollPanel.contentViewChild?.nativeElement) {
+                const el = this.scrollPanel.contentViewChild.nativeElement;
+                el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+                this.scrollPanel.moveBar();
+            }
+        }, 100);
+    }
 
 
-    
+
     ngOnDestroy() {
         if (this.stream) {
             this.stream.getTracks().forEach((track) => track.stop());


### PR DESCRIPTION
I refactored the speak method into smaller sub-methods for better readability and separation of concerns.

I also manually added ngOnDestroy and a destroy$ subject in TextToSpeechService because the service subscribes to another observable that might not complete on its own.

Since services usually live longer than components, failing to unsubscribe can cause memory leaks.

Note: We don’t need this cleanup pattern for HTTP observables because Angular’s HttpClient completes the stream automatically.