### PR TITLE
Update interview meeting and use correct endpoint for saving evaluation

### DIFF
--- a/src/app/core/models/interview-evaluation.ts
+++ b/src/app/core/models/interview-evaluation.ts
@@ -1,0 +1,7 @@
+
+export interface QuestionsAndAnswersForEvaluationDTO {
+  questionDescription: string;
+  answerDescription: string;
+  estimatedAnswerTime?: number;
+  realAnswerTime?: number;
+}

--- a/src/app/core/services/interview-evaluation.service.ts
+++ b/src/app/core/services/interview-evaluation.service.ts
@@ -7,6 +7,7 @@ import { InterviewEvaluationDisplay } from '../models/interview-evaluation-displ
 import { Evaluation } from '../models/evaluation';
 import { Question } from '../models/question';
 import { handleError } from '../constants/http-const';
+import { QuestionsAndAnswersForEvaluationDTO } from '../models/interview-evaluation';
 
 @Injectable({ providedIn: 'root' })
 export class InterviewEvaluationService {
@@ -29,7 +30,7 @@ export class InterviewEvaluationService {
     this.http.get<Evaluation[]>(`${this.interviewsUrl}/${interviewId}/evaluations?type=${evaluationTypeId}`)
       .pipe(retry(2), catchError(err => handleError('Fetching Evaluations by Type', err)));
 
-  prepareInterviewEvaluation = (prompt: string, questions: Question[]): Observable<Evaluation> =>
-    this.http.post<Evaluation>(`${this.evaluationsUrl}/evaluation`, { prompt, questions })
+  prepareInterviewEvaluation = (interviewId: string, questionsAndAnswers: QuestionsAndAnswersForEvaluationDTO[]): Observable<String> =>
+    this.http.post(`${this.interviewsUrl}/${interviewId}/evaluations`, { questionsAndAnswers },{ responseType: 'text' })
       .pipe(retry(2), catchError(err => handleError('Saving Interview Evaluation', err)));
 }

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -41,6 +41,7 @@ import { ScrollPanelModule } from 'primeng/scrollpanel';
 import { Router } from '@angular/router';
 import { cameraTransition, slideInInterview, fadeInControls, slideInTranscript } from '../../../../shared/layout/animations/interview-meeting.animations';
 import { fadeIn } from '../../../../shared/layout/animations/common.animation';
+import { QuestionsAndAnswersForEvaluationDTO } from '../../../../core/models/interview-evaluation';
 
 @Component({
     selector: 'app-interview-meeting',
@@ -93,6 +94,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
     questionInterval: any;
     transcriptions: string[] = [];
     currentTime: string = '';
+    interviewId!: string;
     interviewRules: InterviewRule[] = INTERVIEW_RULES;
     private destroy$ = new Subject<void>();
     private eventListenersRegistered = false;
@@ -147,6 +149,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         this.tokenValidationService.getInterviewIdFromToken(token).subscribe({
             next: (interviewId) => {
                 console.log('Retrieved interview ID:', interviewId);
+                this.interviewId = interviewId;
                 this.loadInterviewQuestions(interviewId);
             },
             error: (err) => {
@@ -598,9 +601,14 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         this.isInterviewFinalizing = false;
         this.isInterviewCompleted = true;
         window.scrollTo(0, 0);
+        const questionsAndAnswers: QuestionsAndAnswersForEvaluationDTO[] = this.questions.map(q => ({
+            questionDescription: q.description,
+            answerDescription: q.answer?.description || '',
+            estimatedAnswerTime: q.durationInMinutes ?? undefined,
+            realAnswerTime: q.answer ? Math.ceil((q.durationInMinutes * 60 - this.timeRemaining) / 60) : undefined
+        }));
 
-        const prompt = 'Evaluate this interview';
-        this.evaluationService.prepareInterviewEvaluation(prompt, this.questions).subscribe({
+        this.evaluationService.prepareInterviewEvaluation(this.interviewId,questionsAndAnswers).subscribe({
             next: (evaluation) => {
                 console.log('Interview Evaluation:', evaluation);
                 this.notify.showSuccess('Interview Completed', 'Your interview has been successfully evaluated.');

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -605,7 +605,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
             questionDescription: q.description,
             answerDescription: q.answer?.description || '',
             estimatedAnswerTime: q.durationInMinutes ?? undefined,
-            realAnswerTime: q.answer ? Math.ceil((q.durationInMinutes * 60 - this.timeRemaining) / 60) : undefined
+            realAnswerTime: q.answer?.durationInMinutes ?? undefined
         }));
 
         this.evaluationService.prepareInterviewEvaluation(this.interviewId,questionsAndAnswers).subscribe({


### PR DESCRIPTION
In this PR, I updated the InterviewMeetingComponent and InterviewEvaluationService to use the correct endpoint for saving interview evaluations.

1. Added the QuestionsAndAnswersForEvaluationDTO model to the frontend.
2. Updated the prepareInterviewEvaluation method to send questionsAndAnswers to /interviews/{id}/evaluations.