### PR TITLE
call prepare-formatted-description endpoint after creating offer

### DIFF
--- a/src/app/core/services/offer.service.ts
+++ b/src/app/core/services/offer.service.ts
@@ -77,4 +77,10 @@ export class OfferService {
     return this.http.get<OfferFormattedDescription>(`${this.apiUrl}/${offerId}/formatted-description`)
     .pipe(retry(2));
   }
+
+  prepareOfferFormattedDescription(offerId: string): Observable<OfferFormattedDescription> {
+    return this.http.post<OfferFormattedDescription>(`${this.apiUrl}/${offerId}/prepare-formatted-description`,{})
+    .pipe(retry(2));
+  }
+
 }

--- a/src/app/features/offer/components/new-offer/new-offer.component.ts
+++ b/src/app/features/offer/components/new-offer/new-offer.component.ts
@@ -45,8 +45,16 @@ export class NewOfferComponent {
     const payload = this.offerForm.value; // { title, description }
 
     this.offerService.addOffer(payload).subscribe({
-      next: () => {
-        this.router.navigate(['/offers']);
+      next: (createdOffer) => {
+        this.offerService.prepareOfferFormattedDescription(createdOffer.id).subscribe({
+          next: (formatted) => {
+            console.log('Formatted description:', formatted);
+            this.router.navigate(['/offers']);
+          },
+          error: (err) => {
+            console.error('Error preparing formatted description', err);
+          }
+        });
       },
       error: (err) => {
         console.error('Error creating offer', err);


### PR DESCRIPTION
In this pr I: 
- Updated OfferService to call the POST /offers/{id}/prepare-formatted-description endpoint.
- Updated NewOfferComponent to trigger the formatted description generation immediately after successfully creating an offer.
