### PR TITLE
Recording logic

### DIFF
--- a/src/app/core/models/merge-recordings.ts
+++ b/src/app/core/models/merge-recordings.ts
@@ -1,4 +1,5 @@
 export interface MergeRecordings{
     interviewId: string;
     transcript: string;
+    chunk: Blob
 }

--- a/src/app/core/models/merge-recordings.ts
+++ b/src/app/core/models/merge-recordings.ts
@@ -1,0 +1,4 @@
+export interface MergeRecordings{
+    interviewId: string;
+    transcript: string;
+}

--- a/src/app/core/models/uploadChunkRequest.ts
+++ b/src/app/core/models/uploadChunkRequest.ts
@@ -1,5 +1,5 @@
 export interface UploadChunkRequest{
     interviewId: string;
     chunk: Blob;
-    sequence: number
+    sequence: number;
 }

--- a/src/app/core/models/uploadChunkRequest.ts
+++ b/src/app/core/models/uploadChunkRequest.ts
@@ -1,0 +1,5 @@
+export interface UploadChunkRequest{
+    interviewId: string;
+    chunk: Blob;
+    sequence: number
+}

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -4,6 +4,8 @@ import { Record } from '../models/record';
 import { firstValueFrom, Observable, retry, catchError, throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { UploadChunkRequest } from '../models/uploadChunkRequest';
+import { MergeRecordings } from '../models/merge-recordings';
+import { handleError } from '../constants/http-const';
 
 @Injectable({
   providedIn: 'root'
@@ -94,4 +96,18 @@ export class RecordingService {
       throw Error(`Still ${this.failedRequestsAfterMaxRetries.length} chunks failed after retry.`)
     }
   }
+
+  mergeChunks = (interviewId: string, transcript: string): Observable<string> => {
+    const request: MergeRecordings = {
+      interviewId: interviewId,
+      transcript: transcript
+    }
+
+    return this.http.post<string>(
+      `${this.apiUrl}/merge`,
+      request
+    ).pipe(catchError((err)=>handleError("Interview",err)));
+    // I passed interview as the entity because in the merge function we fecth the interview not the recording
+  }
+
 }

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -10,7 +10,7 @@ import { environment } from '../../../environments/environment';
 })
 export class RecordService {
   // Mockoon endpoint
-  private apiUrl = `${environment.apiInterviews}/records`;
+  private apiUrl = `${environment.apiInterviews}/recordings`;
 
 
   constructor(private http: HttpClient) { }

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -102,15 +102,14 @@ export class RecordingService {
   }
 
   mergeChunks = (interviewId: string, transcript: string, lastChunk: Blob): Observable<string> => {
-    const request: MergeRecordings = {
-      interviewId: interviewId,
-      transcript: transcript,
-      chunk: lastChunk
-    }
+    const formData = new FormData();
+    formData.append("interviewId",interviewId)
+    formData.append("transcript",transcript)
+    formData.append("chunk",lastChunk)
 
     return this.http.post<string>(
       `${this.apiUrl}/merge`,
-      request
+      formData
     ).pipe(catchError((err) => handleError("Interview", err)));
     // I passed interview as the entity because in the merge function we fecth the interview not the recording
   }

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Record } from '../models/record';
-import { firstValueFrom, Observable, retry,catchError, throwError } from 'rxjs';
+import { firstValueFrom, Observable, retry, catchError, throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { UploadChunkRequest } from '../models/uploadChunkRequest';
 
@@ -22,10 +22,10 @@ export class RecordingService {
     return this.http.post<Record>(this.apiUrl, record);
   }
 
-  uploadChunk = (request: UploadChunkRequest): Observable<any> => {
+  uploadChunk = (request: UploadChunkRequest): Observable<string> => {
     const headers = new HttpHeaders();
 
-    return this.http.post(
+    return this.http.post<string>(
       `${this.apiUrl}/upload`,
       request
     );
@@ -38,11 +38,7 @@ export class RecordingService {
       try {
         const response = await firstValueFrom(this.uploadChunk(request));
 
-        if (response && response.success) {
-          return true;
-        } else {
-          throw new Error('Server did not confirm success');
-        }
+        return true;
       } catch (err: any) {
         retryCount++;
         console.error(`Failed to upload chunk ${request.sequence}, attempt ${retryCount}:`, err);
@@ -52,11 +48,14 @@ export class RecordingService {
           const errMsg = typeof err === 'string'
             ? err
             : (err?.error?.message || err?.message || 'Unknown error');
+          console.error(errMsg);
+          this.failedRequestsAfterMaxRetries.push(request);
+          throw Error(errMsg);
         }
       }
     }
 
-    this.failedRequestsAfterMaxRetries.push(request);
+
     return false;
   }
 
@@ -82,7 +81,7 @@ export class RecordingService {
       } catch (err) {
         failedNow.push(chunk);
         console.error('Unexpected error while retrying chunk:', err);
-        throw Error('Unexpected error while retrying chunk: '+err) 
+        throw Error('Unexpected error while retrying chunk: ' + err)
       }
     }
 

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -15,7 +15,7 @@ export class RecordingService {
   private retryDelay = 1000;
   private failedRequestsAfterMaxRetries: UploadChunkRequest[] = [];
 
-  private apiUrl = `${environment.apiInterviews}/v1/recordings`;
+  private apiUrl = `${environment.apiUrl}/v1/recordings`;
 
 
   constructor(private http: HttpClient) { }
@@ -27,9 +27,13 @@ export class RecordingService {
   uploadChunk = (request: UploadChunkRequest): Observable<string> => {
     const headers = new HttpHeaders();
 
+    const formData = new FormData();
+    formData.append('interviewId', request.interviewId);
+    formData.append('sequence', request.sequence.toString());
+    formData.append('chunk', request.chunk);
     return this.http.post<string>(
       `${this.apiUrl}/upload`,
-      request
+      formData
     );
   }
 
@@ -106,7 +110,7 @@ export class RecordingService {
     return this.http.post<string>(
       `${this.apiUrl}/merge`,
       request
-    ).pipe(catchError((err)=>handleError("Interview",err)));
+    ).pipe(catchError((err) => handleError("Interview", err)));
     // I passed interview as the entity because in the merge function we fecth the interview not the recording
   }
 

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -1,21 +1,98 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Record } from '../models/record';
-import { Observable } from 'rxjs';
+import { firstValueFrom, Observable, retry,catchError, throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
-
+import { UploadChunkRequest } from '../models/uploadChunkRequest';
 
 @Injectable({
   providedIn: 'root'
 })
-export class RecordService {
-  // Mockoon endpoint
-  private apiUrl = `${environment.apiInterviews}/recordings`;
+export class RecordingService {
+  private maxRetries = 3;
+  private retryDelay = 1000;
+  private failedRequestsAfterMaxRetries: UploadChunkRequest[] = [];
+
+  private apiUrl = `${environment.apiInterviews}/v1/recordings`;
 
 
   constructor(private http: HttpClient) { }
 
   saveRecord(record: Record): Observable<Record> {
     return this.http.post<Record>(this.apiUrl, record);
+  }
+
+  uploadChunk = (request: UploadChunkRequest): Observable<any> => {
+    const headers = new HttpHeaders();
+
+    return this.http.post(
+      `${this.apiUrl}/upload`,
+      request
+    );
+  }
+
+  async uploadChunkWithRetry(request: UploadChunkRequest): Promise<boolean> {
+    let retryCount = 0;
+
+    while (retryCount < this.maxRetries) {
+      try {
+        const response = await firstValueFrom(this.uploadChunk(request));
+
+        if (response && response.success) {
+          return true;
+        } else {
+          throw new Error('Server did not confirm success');
+        }
+      } catch (err: any) {
+        retryCount++;
+        console.error(`Failed to upload chunk ${request.sequence}, attempt ${retryCount}:`, err);
+        if (retryCount <= this.maxRetries) {
+          await this.delay(this.retryDelay * Math.pow(2, retryCount - 1));
+        } else {
+          const errMsg = typeof err === 'string'
+            ? err
+            : (err?.error?.message || err?.message || 'Unknown error');
+        }
+      }
+    }
+
+    this.failedRequestsAfterMaxRetries.push(request);
+    return false;
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async retryFailedUploads(): Promise<void> {
+    if (this.failedRequestsAfterMaxRetries.length === 0) {
+      console.log('No failed uploads to retry.');
+      return;
+    }
+
+    console.log(`Retrying ${this.failedRequestsAfterMaxRetries.length} failed uploads...`);
+    const failedNow: UploadChunkRequest[] = [];
+
+    for (const chunk of this.failedRequestsAfterMaxRetries) {
+      try {
+        const success = await this.uploadChunkWithRetry(chunk);
+        if (!success) {
+          failedNow.push(chunk);
+        }
+      } catch (err) {
+        failedNow.push(chunk);
+        console.error('Unexpected error while retrying chunk:', err);
+        throw Error('Unexpected error while retrying chunk: '+err) 
+      }
+    }
+
+    this.failedRequestsAfterMaxRetries = failedNow;
+
+    if (this.failedRequestsAfterMaxRetries.length === 0) {
+      console.log('All failed uploads retried successfully.');
+    } else {
+      console.warn(`Still ${this.failedRequestsAfterMaxRetries.length} chunks failed after retry.`);
+      throw Error(`Still ${this.failedRequestsAfterMaxRetries.length} chunks failed after retry.`)
+    }
   }
 }

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders , HttpErrorResponse} from '@angular/common/http';
 import { Record } from '../models/record';
-import { firstValueFrom, Observable, retry, catchError, throwError } from 'rxjs';
+import { firstValueFrom, Observable, retry, catchError, map ,of } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { UploadChunkRequest } from '../models/uploadChunkRequest';
-import { MergeRecordings } from '../models/merge-recordings';
 import { handleError } from '../constants/http-const';
 
 @Injectable({
@@ -31,9 +30,10 @@ export class RecordingService {
     formData.append('interviewId', request.interviewId);
     formData.append('sequence', request.sequence.toString());
     formData.append('chunk', request.chunk);
-    return this.http.post<string>(
+    return this.http.post(
       `${this.apiUrl}/upload`,
-      formData
+      formData,
+      { responseType: 'text' }
     );
   }
 
@@ -101,16 +101,26 @@ export class RecordingService {
     }
   }
 
-  mergeChunks = (interviewId: string, transcript: string, lastChunk: Blob): Observable<string> => {
+  mergeChunks = (interviewId: string, transcript: string, lastChunk: Blob): Observable<string | null> => {
     const formData = new FormData();
-    formData.append("interviewId",interviewId)
-    formData.append("transcript",transcript)
-    formData.append("chunk",lastChunk)
+    formData.append("interviewId", interviewId)
+    formData.append("transcript", transcript)
+    formData.append("chunk", lastChunk)
 
-    return this.http.post<string>(
+    return this.http.post(
       `${this.apiUrl}/merge`,
-      formData
-    ).pipe(catchError((err) => handleError("Interview", err)));
+      formData,
+      { responseType: 'text' }
+    ).pipe(
+      retry(3),
+      catchError((err: HttpErrorResponse) => {
+        if (err.status === 404) {
+          console.warn(`Interview not found`);
+          return of(null); 
+        }
+        return handleError("Interview", err); 
+      })
+    );
     // I passed interview as the entity because in the merge function we fecth the interview not the recording
   }
 

--- a/src/app/core/services/recording.service.ts
+++ b/src/app/core/services/recording.service.ts
@@ -101,10 +101,11 @@ export class RecordingService {
     }
   }
 
-  mergeChunks = (interviewId: string, transcript: string): Observable<string> => {
+  mergeChunks = (interviewId: string, transcript: string, lastChunk: Blob): Observable<string> => {
     const request: MergeRecordings = {
       interviewId: interviewId,
-      transcript: transcript
+      transcript: transcript,
+      chunk: lastChunk
     }
 
     return this.http.post<string>(

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -16,7 +16,7 @@ import { MessageService } from 'primeng/api';
 import { DividerModule } from 'primeng/divider';
 import { TagModule } from 'primeng/tag';
 import { SkeletonModule } from 'primeng/skeleton';
-import { RecordService } from '../../../../core/services/record.service';
+import { RecordService } from '../../../../core/services/recording.service';
 import { Record } from '../../../../core/models/record';
 import { PromptService } from '../../../../core/services/prompt.service';
 import { Question } from '../../../../core/models/question';
@@ -99,6 +99,9 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
     private destroy$ = new Subject<void>();
     private eventListenersRegistered = false;
     interviewToken: any;
+    chunkTimer: any;
+    // with this the chunks will be sent each 100 seconds you can change it based on your needs
+    private chunkInterval = 100000;
 
     constructor(
         private recordService: RecordService,
@@ -333,7 +336,17 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
             this.processRecordedData();
         };
 
+        this.startChunkRecording();
+    }
+
+    private startChunkRecording():void{
         this.mediaRecorder.start();
+
+        this.chunkTimer = setInterval(() =>{
+            if(this.mediaRecorder && this.mediaRecorder.state==='recording'){
+                this.mediaRecorder.requestData();
+            }
+        }, this.chunkInterval)
     }
 
     private processRecordedData(): void {

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -348,7 +348,6 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
 
         this.mediaRecorder.onstop = () => {
             clearInterval(this.chunkTimer);
-            this.mediaRecorder.requestData();
             setTimeout(async () => {
                 await this.mergeChunksAfterMediaRecorderStop();
                 console.log('All chunks merged and interview finalized.');

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -16,7 +16,7 @@ import { MessageService } from 'primeng/api';
 import { DividerModule } from 'primeng/divider';
 import { TagModule } from 'primeng/tag';
 import { SkeletonModule } from 'primeng/skeleton';
-import { RecordService } from '../../../../core/services/recording.service';
+import { RecordingService } from '../../../../core/services/recording.service';
 import { Record } from '../../../../core/models/record';
 import { PromptService } from '../../../../core/services/prompt.service';
 import { Question } from '../../../../core/models/question';
@@ -42,6 +42,7 @@ import { Router } from '@angular/router';
 import { cameraTransition, slideInInterview, fadeInControls, slideInTranscript } from '../../../../shared/layout/animations/interview-meeting.animations';
 import { fadeIn } from '../../../../shared/layout/animations/common.animation';
 import { QuestionsAndAnswersForEvaluationDTO } from '../../../../core/models/interview-evaluation';
+import { UploadChunkRequest } from '../../../../core/models/uploadChunkRequest';
 
 @Component({
     selector: 'app-interview-meeting',
@@ -102,9 +103,10 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
     chunkTimer: any;
     // with this the chunks will be sent each 100 seconds you can change it based on your needs
     private chunkInterval = 100000;
+    private chunkSequence = 0;
 
     constructor(
-        private recordService: RecordService,
+        private recordingService: RecordingService,
         private promptService: PromptService,
         // Removed: private tts: TextToSpeechService,
         private evaluationService: InterviewEvaluationService,
@@ -114,8 +116,8 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         private router: Router,
         private activatedRoute: ActivatedRoute,
         private interviewService: InterviewService,
-        private tokenValidationService: TokenValidationService
-    ) {}
+        private tokenValidationService: TokenValidationService,
+    ) { }
 
     ngOnInit(): void {
         this.initializeComponent();
@@ -321,6 +323,8 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
 
     private setupMediaRecorder(): void {
         this.recordedChunks = [];
+        this.chunkSequence = 0;
+
         this.mediaRecorder = new MediaRecorder(this.stream!, {
             mimeType: 'video/webm;codecs=vp9'
         });
@@ -328,7 +332,10 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
 
         this.mediaRecorder.ondataavailable = (event: BlobEvent) => {
             if (event.data.size > 0) {
+                console.log(` Chunk ${this.chunkSequence} received, size: ${event.data.size} bytes`);
+
                 this.recordedChunks.push(event.data);
+                this.uploadChunkImmediately(event.data);
             }
         };
 
@@ -339,14 +346,34 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         this.startChunkRecording();
     }
 
-    private startChunkRecording():void{
+    private startChunkRecording(): void {
         this.mediaRecorder.start();
 
-        this.chunkTimer = setInterval(() =>{
-            if(this.mediaRecorder && this.mediaRecorder.state==='recording'){
+        this.chunkTimer = setInterval(() => {
+            if (this.mediaRecorder && this.mediaRecorder.state === 'recording') {
                 this.mediaRecorder.requestData();
             }
         }, this.chunkInterval)
+    }
+
+    private async uploadChunkImmediately(chunkBlob: Blob): Promise<void> {
+
+        const req: UploadChunkRequest = {
+            interviewId: this.interviewId,
+            chunk: chunkBlob,
+            sequence: this.chunkInterval
+        }
+        try {
+            const success = await this.recordingService.uploadChunkWithRetry(req);
+            if (!success) {
+                console.error(`Failed to upload chunk with sequence ${req.sequence}`);
+                this.notify.showError('Error', 'Failed to upload chunk with sequence ${req.sequence}')
+            }
+            this.chunkSequence++;
+        }
+        catch (error: any) {
+            this.notify.showError("Error", error)
+        }
     }
 
     private processRecordedData(): void {
@@ -365,7 +392,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
             transcriptionFileUrl: ''
         };
 
-        this.recordService.saveRecord(this.interviewRecord).subscribe({
+        this.recordingService.saveRecord(this.interviewRecord).subscribe({
             next: () => {
                 console.log('✅ Record saved');
                 this.finalizeRecording();
@@ -599,13 +626,21 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         }
     }
 
-    finalizeRecording(): void {
+    async finalizeRecording(): Promise<void> {
         this.isInterviewFinalizing = false;
         this.isInterviewCompleted = true;
         console.log(
             'All answers captured via speech:',
             this.questions.map((q) => q.answer)
         );
+
+        try {
+            await this.recordingService.retryFailedUploads();
+        } catch (err) {
+            console.error('Error retrying failed uploads:', err);
+            const errorMsg = err instanceof Error ? err.message : String(err);
+            this.notify.showError('Error retrying failed uploads', errorMsg);
+        }
         window.scrollTo(0, 0);
         this.notify.showSuccess('Interview Completed', 'Your interview has been successfully recorded and saved.');
     }
@@ -621,7 +656,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
             realAnswerTime: q.answer?.durationInMinutes ?? undefined
         }));
 
-        this.evaluationService.prepareInterviewEvaluation(this.interviewId,questionsAndAnswers).subscribe({
+        this.evaluationService.prepareInterviewEvaluation(this.interviewId, questionsAndAnswers).subscribe({
             next: (evaluation) => {
                 console.log('Interview Evaluation:', evaluation);
                 this.notify.showSuccess('Interview Completed', 'Your interview has been successfully evaluated.');
@@ -639,6 +674,10 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
     private cleanupInterviewResources(): void {
         this.stopSpeechRecognition();
         this.clearQuestionTimer();
+        if (this.chunkTimer) {
+            clearInterval(this.chunkTimer);
+            this.chunkTimer = null;
+        }
         this.releaseMediaStream();
         this.removeEventListeners();
         this.exitFullscreenMode();

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -3,7 +3,7 @@ import { trigger, state, style, transition, animate } from '@angular/animations'
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { takeUntil } from 'rxjs/operators';
-import { Subject } from 'rxjs';
+import { firstValueFrom, Subject } from 'rxjs';
 import { INTERVIEW_RULES, InterviewRule } from '../../../../core/constants/interview-rules.const';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -104,6 +104,8 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
     // with this the chunks will be sent each 100 seconds you can change it based on your needs
     private chunkInterval = 100000;
     private chunkSequence = 0;
+    private lastChunkBlob: Blob | null = null;
+    private inflight = new Set<Promise<any>>();
 
     constructor(
         private recordingService: RecordingService,
@@ -335,12 +337,22 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
                 console.log(` Chunk ${this.chunkSequence} received, size: ${event.data.size} bytes`);
 
                 this.recordedChunks.push(event.data);
-                this.uploadChunkImmediately(event.data);
+                this.lastChunkBlob = event.data;
+                if (this.mediaRecorder.state === 'recording') {
+                    this.uploadChunkImmediately(event.data);
+                }
+
+                this.chunkSequence++;
             }
         };
 
         this.mediaRecorder.onstop = () => {
-            this.processRecordedData();
+            clearInterval(this.chunkTimer);
+            this.mediaRecorder.requestData();
+            setTimeout(async () => {
+                await this.mergeChunksAfterMediaRecorderStop();
+                console.log('All chunks merged and interview finalized.');
+            }, 100);
         };
 
         this.startChunkRecording();
@@ -361,47 +373,55 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         const req: UploadChunkRequest = {
             interviewId: this.interviewId,
             chunk: chunkBlob,
-            sequence: this.chunkInterval
+            sequence: this.chunkSequence
         }
-        try {
-            const success = await this.recordingService.uploadChunkWithRetry(req);
-            if (!success) {
-                console.error(`Failed to upload chunk with sequence ${req.sequence}`);
-                this.notify.showError('Error', 'Failed to upload chunk with sequence ${req.sequence}')
-            }
-            this.chunkSequence++;
-        }
-        catch (error: any) {
-            this.notify.showError("Error", error)
-        }
+
+        const uploadPromise = this.recordingService.uploadChunkWithRetry(req)
+            .catch((error) => {
+                console.error('Chunk upload failed:', error);
+                this.notify.showError("Error", error);
+            })
+            .finally(() => {
+                this.inflight.delete(uploadPromise);
+            });
+
+        this.inflight.add(uploadPromise);
+
+        await uploadPromise;
     }
 
-    private processRecordedData(): void {
-        const blob = new Blob(this.recordedChunks, { type: 'video/webm' });
-        this.recordedBlobUrl = URL.createObjectURL(blob);
-        const duration = Math.floor((Date.now() - this.interviewStartTime) / 1000);
+    private async mergeChunksAfterMediaRecorderStop() {
+        try {
+            await this.recordingService.retryFailedUploads();
 
-        this.interviewRecord = {
-            id: Date.now().toString(),
-            interviewId: 1,
-            recordedAt: new Date(),
-            durationInSeconds: duration,
-            fileName: `interview-${Date.now()}.webm`,
-            fileUrl: this.recordedBlobUrl,
-            uploaded: false,
-            transcriptionFileUrl: ''
-        };
-
-        this.recordingService.saveRecord(this.interviewRecord).subscribe({
-            next: () => {
-                console.log('✅ Record saved');
-                this.finalizeRecording();
-            },
-            error: (err) => {
-                console.error('❌ Error saving record:', err);
-                this.finalizeRecording();
+            if (this.inflight.size > 0) {
+                console.log(`Waiting for ${this.inflight.size} pending uploads to complete...`);
+                await Promise.all(this.inflight);
             }
-        });
+
+            if (this.lastChunkBlob) {
+                try {
+
+                    await firstValueFrom(
+                        this.recordingService.mergeChunks(
+                            this.interviewId,
+                            '',
+                            this.lastChunkBlob
+                        )
+                    );
+                } catch (error) {
+                    console.error('Final chunk processing failed:', error);
+                }
+            }
+
+        } catch (error) {
+            console.error('Final processing failed:', error);
+            this.notify.showError(
+                'Merge Error',
+                `Failed to merge interview chunks: ${error instanceof Error ? error.message : error}`
+            );
+
+        }
     }
 
     private attachEventListeners(): void {
@@ -596,7 +616,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         }
 
         this.finalizeInterviewAndSaveEvaluation();
-        this.recordingService.mergeChunks(this.interviewId,"");
+
         this.cleanupInterviewResources();
 
         console.log(
@@ -635,13 +655,6 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
             this.questions.map((q) => q.answer)
         );
 
-        try {
-            await this.recordingService.retryFailedUploads();
-        } catch (err) {
-            console.error('Error retrying failed uploads:', err);
-            const errorMsg = err instanceof Error ? err.message : String(err);
-            this.notify.showError('Error retrying failed uploads', errorMsg);
-        }
         window.scrollTo(0, 0);
         this.notify.showSuccess('Interview Completed', 'Your interview has been successfully recorded and saved.');
     }

--- a/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
+++ b/src/app/features/interviews/components/interview-meeting/interview-meeting.component.ts
@@ -596,6 +596,7 @@ export class InterviewMeetingComponent implements AfterViewInit, OnDestroy {
         }
 
         this.finalizeInterviewAndSaveEvaluation();
+        this.recordingService.mergeChunks(this.interviewId,"");
         this.cleanupInterviewResources();
 
         console.log(


### PR DESCRIPTION

Added: 

  - calling upload endpoint in recording service ( we send the sequence of the chunk, the multipartfile, and the interview Id)
  - merging endpoint we send just the interview id
  - we added also a logic for retrying if the upload fails
 In interview meeting component:
  - the uploading is triggered every 100 seconds with  startChunkRecording
  - the merging endpoint is called after the interview is finished